### PR TITLE
Improved vcs parsing rules.

### DIFF
--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -90,7 +90,7 @@ def parse_req_file(req_file, colour=TextColours(False)):
 
         # it matching VCS requirement spec., log to stderr, continue
         vcs_match = re.match(
-            '\s*(?:(-e){0,1}\s+)?(?P<vcsscheme>(svn|git|hg|bzr))\+',
+            '\s*(?:(-e){0,1}\s+)?(?P<vcsscheme>(svn|git|hg|bzr))(?:\+|://)',
             requirement)
 
         if vcs_match:


### PR DESCRIPTION
It wasn't catching these two lines:

```
git+git://github.com/Celc/facebook-sdk.git#egg=facebook-sdk
-e git://github.com/mjallday/django-paypal.git@794e40d646701c4bd0e5e3330649ff383fd9eaa1#egg=django_paypal-dev
```
