### PR TITLE
Make requests run concurrently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 install:
   - pip install -q six==1.5.2
   - pip install -q requests==$REQUESTS_VERSION
+  - pip install -q requests-futures==0.9.4
 
 # command to run tests
 script:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     },
     install_requires=[
         'requests',
-        'six'
+        'six',
+        'requests-futures'
     ]
 )


### PR DESCRIPTION
I've added concurrency so things run a little faster.

Before a `requirements.txt` file of 80 items would take 30 seconds to complete. With this change we are down to 10 seconds.
