### PR TITLE
Adds --force argument, to ease integration with CI setups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,18 +104,6 @@ better tools for working with packages installed in your environment.
     pip freeze | piprot
 
 
-The ``--force`` argument will return a non-zero exit code, if requirements
-are out of date. Useful for integrating in an automated testing / CI setup.
-
-::
-
-    > piprot --force
-    ipython (1.1.0) is 331 days out of date. Latest is 2.2.0
-    ipython==2.2.0 # Updated from 1.1.0
-    > echo $?
-    1
-
-
 (New in 0.9) You can also lookup requirements from a Github repo with the ``--github``,
 ``--branch`` and ``--path`` options. Additionally you can use ``--token`` to
 supply a `Personal Access Token` to remotely test private repositories.

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,11 @@ creating a sort-of ''perfect'' requirements file for me,
 Yep, you can use stdin as well if you really want to, but there are
 better tools for working with packages installed in your environment.
 
+::
+
+    pip freeze | piprot
+
+
 The ``--force`` argument will return a non-zero exit code, if requirements
 are out of date. Useful for integrating in an automated testing / CI setup.
 
@@ -109,10 +114,6 @@ are out of date. Useful for integrating in an automated testing / CI setup.
     ipython==2.2.0 # Updated from 1.1.0
     > echo $?
     1
-
-::
-
-    pip freeze | piprot
 
 
 (New in 0.9) You can also lookup requirements from a Github repo with the ``--github``,

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,17 @@ creating a sort-of ''perfect'' requirements file for me,
 Yep, you can use stdin as well if you really want to, but there are
 better tools for working with packages installed in your environment.
 
+The ``--force`` argument will return a non-zero exit code, if requirements
+are out of date. Useful for integrating in an automated testing / CI setup.
+
+::
+
+    > piprot --force
+    ipython (1.1.0) is 331 days out of date. Latest is 2.2.0
+    ipython==2.2.0 # Updated from 1.1.0
+    > echo $?
+    1
+
 ::
 
     pip freeze | piprot

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ supply a `Personal Access Token` to remotely test private repositories.
     requests-futures (0.9.5) is up to date
     six (1.8.0) is up to date
     piprot (0.8.2) is up to date
-    Looks like you've been keeping up to date,time for a delicious beverage!
+    Looks like you've been keeping up to date, time for a delicious beverage!
 
 
 Working with your environment

--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -129,8 +129,8 @@ def get_version_and_release_date(requirement, version=None,
         return None, None
 
 
-def main(req_files, verbose=False, outdated=False, latest=False,
-         verbatim=False, notify='', reset=False, repo=None, path='requirements.txt',
+def main(req_files, verbose=False, outdated=False, latest=False, verbatim=False,
+         force=False, notify='', reset=False, repo=None, path='requirements.txt',
          token=None, branch='master', url=None):
     """Given a list of requirements files reports which requirements are out
     of date.
@@ -142,6 +142,7 @@ def main(req_files, verbose=False, outdated=False, latest=False,
     - verbatim outputs the requirements file as-is - with comments showing the
       latest versions (can be used with latest to output the latest with the old
       version in the comment)
+    - force exits with a non-zero code if anything is out-of-date
     - notify is a string that should be an email address to upload to piprot.io
     - reset goes with the notification to decide whether to reset the packages
       subscribed to.
@@ -247,8 +248,10 @@ def main(req_files, verbose=False, outdated=False, latest=False,
     if total_time_delta > 0:
         print("{}Your requirements are {} "
               "days out of date".format(verbatim_str, total_time_delta))
+        if force:
+            sys.exit(1)
     else:
-        print("{}Looks like you've been keeping up to date,"
+        print("{}Looks like you've been keeping up to date, "
               "time for a delicious beverage!".format(verbatim_str))
 
 
@@ -307,6 +310,8 @@ def piprot():
                                  '(<0.3 behaviour)')
     cli_parser.add_argument('-o', '--outdated', action='store_true',
                             help='only list outdated requirements')
+    cli_parser.add_argument('-f', '--force', action='store_true',
+                            help='fail if all requirements are not up to date')
 
     cli_parser.add_argument('-n', '--notify',
                             help='submit requirements to piprot notify for '
@@ -372,7 +377,7 @@ def piprot():
 
     # call the main function to kick off the real work
     main(req_files=cli_args.file, verbose=verbose, outdated=cli_args.outdated,
-         latest=cli_args.latest, verbatim=cli_args.verbatim,
+         latest=cli_args.latest, verbatim=cli_args.verbatim, force=cli_args.force,
          notify=cli_args.notify, reset=cli_args.reset, repo=cli_args.github,
          branch=cli_args.branch, path=cli_args.path, token=cli_args.token,
          url=cli_args.url)

--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -129,8 +129,8 @@ def get_version_and_release_date(requirement, version=None,
         return None, None
 
 
-def main(req_files, verbose=False, outdated=False, latest=False, verbatim=False,
-         force=False, notify='', reset=False, repo=None, path='requirements.txt',
+def main(req_files, verbose=False, outdated=False, latest=False,
+         verbatim=False, notify='', reset=False, repo=None, path='requirements.txt',
          token=None, branch='master', url=None):
     """Given a list of requirements files reports which requirements are out
     of date.
@@ -142,7 +142,6 @@ def main(req_files, verbose=False, outdated=False, latest=False, verbatim=False,
     - verbatim outputs the requirements file as-is - with comments showing the
       latest versions (can be used with latest to output the latest with the old
       version in the comment)
-    - force exits with a non-zero code if anything is out-of-date
     - notify is a string that should be an email address to upload to piprot.io
     - reset goes with the notification to decide whether to reset the packages
       subscribed to.
@@ -248,8 +247,7 @@ def main(req_files, verbose=False, outdated=False, latest=False, verbatim=False,
     if total_time_delta > 0:
         print("{}Your requirements are {} "
               "days out of date".format(verbatim_str, total_time_delta))
-        if force:
-            sys.exit(1)
+        sys.exit(1)
     else:
         print("{}Looks like you've been keeping up to date, "
               "time for a delicious beverage!".format(verbatim_str))
@@ -310,8 +308,6 @@ def piprot():
                                  '(<0.3 behaviour)')
     cli_parser.add_argument('-o', '--outdated', action='store_true',
                             help='only list outdated requirements')
-    cli_parser.add_argument('-f', '--force', action='store_true',
-                            help='fail if all requirements are not up to date')
 
     cli_parser.add_argument('-n', '--notify',
                             help='submit requirements to piprot notify for '
@@ -377,7 +373,7 @@ def piprot():
 
     # call the main function to kick off the real work
     main(req_files=cli_args.file, verbose=verbose, outdated=cli_args.outdated,
-         latest=cli_args.latest, verbatim=cli_args.verbatim, force=cli_args.force,
+         latest=cli_args.latest, verbatim=cli_args.verbatim,
          notify=cli_args.notify, reset=cli_args.reset, repo=cli_args.github,
          branch=cli_args.branch, path=cli_args.path, token=cli_args.token,
          url=cli_args.url)


### PR DESCRIPTION
Hey there, 

Love piprot, thanks for writing it!

This is a small PR to add an exit code option, so I can drop piprot in things like [polytester](https://github.com/skoczen/polytester) and have it Just Work.

I've also included a small grammatical tweak.

A couple of notes:

1. I'm not sure if you'd prefer to just have this be the default behavior. I couldn't see a reason not to return exit codes by default, but didn't want to presume. Happy to update this PR to remove the flag, and just return automatically if you'd prefer.
2. If you do prefer the flag, I'm not totally sold on `--force` being the best name. Suggestions/replacements are welcome!

Thanks again for piprot - love being able to keep things up to date.