### PR TITLE
Fix KeyError in get_version_and_release_date

### DIFF
--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -188,7 +188,7 @@ def get_version_and_release_date(requirement, version=None,
         if version:
             release_date = response['releases'][version][0]['upload_time']
         else:
-            version = response['info']['stable_version']
+            version = response['info'].get('stable_version')
 
             if not version:
                 versions = {


### PR DESCRIPTION
Some packages don't have a `stable_version` when they reach here. Example: https://pypi.python.org/pypi/factory_boy/2.5.1/json