### PR TITLE
Added support for requirements with extras (eg. requests[security]==1.2.3)

### DIFF
--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -115,7 +115,7 @@ def parse_req_file(req_file, verbatim=False):
 
         # if matching requirement line (Thing==1.2.3), update dict, continue
         req_match = re.match(
-            r'\s*(?P<package>\S+)(?P<extras>\[\S+\])?==(?P<version>\S+)',
+            r'\s*(?P<package>[^\s\[\]]+)(?P<extras>\[\S+\])?==(?P<version>\S+)',
             requirement_no_comments
         )
         if req_match:

--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -114,8 +114,10 @@ def parse_req_file(req_file, verbatim=False):
         requirement_no_comments = requirement.split('#')[0].strip()
 
         # if matching requirement line (Thing==1.2.3), update dict, continue
-        req_match = re.match(r'\s*(?P<package>\S+)==(?P<version>\S+)',
-                             requirement_no_comments)
+        req_match = re.match(
+            r'\s*(?P<package>\S+)(?P<extras>\[\S+\])?==(?P<version>\S+)',
+            requirement_no_comments
+        )
         if req_match:
             req_list.append((req_match.group('package'),
                              req_match.group('version')))

--- a/piprot/test/test_parser.py
+++ b/piprot/test/test_parser.py
@@ -16,6 +16,12 @@ class TestRequirementsParser(unittest.TestCase):
         self.assertTrue(d[0][0] == 'requests')
         self.assertTrue(d[0][1] == '1.2.3')
 
+    def test_requirements_with_extra(self):
+        f = StringIO("requests[security]==1.2.3")
+        d = parse_req_file(f)
+        self.assertTrue(d[0][0] == 'requests')
+        self.assertTrue(d[0][1] == '1.2.3')
+
     def test_requirements_file(self):
         with open(
             os.path.join(os.path.dirname(__file__), 'files/_develop.txt')

--- a/piprot/test/test_parser.py
+++ b/piprot/test/test_parser.py
@@ -19,8 +19,8 @@ class TestRequirementsParser(unittest.TestCase):
     def test_requirements_with_extra(self):
         f = StringIO("requests[security]==1.2.3")
         d = parse_req_file(f)
-        self.assertTrue(d[0][0] == 'requests')
-        self.assertTrue(d[0][1] == '1.2.3')
+        self.assertEqual(d[0][0], 'requests')
+        self.assertEqual(d[0][1], '1.2.3')
 
     def test_requirements_file(self):
         with open(


### PR DESCRIPTION
I believe it is not really needed to recursively scan the requirements. If you want the sub dependencies checked as well, it be more logical to add the sub requirements as primary requirements.