### PR TITLE
Add ability to ignore packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,14 @@ supply a `Personal Access Token` to remotely test private repositories.
     piprot (0.8.2) is up to date
     Looks like you've been keeping up to date, time for a delicious beverage!
 
+You can also ignore packages using a norot comment in your requirements file.
+
+::
+   
+   # Inside requirements.txt
+   # Note: two spaces before # norot
+   Django==1.6.5  # norot
+   
 
 Working with your environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/piprot/test/test_github.py
+++ b/piprot/test/test_github.py
@@ -45,7 +45,7 @@ class TestGithubURLs(unittest.TestCase):
         response = requests.get(url)
         req_file = StringIO(response.text)
         requirements = parse_req_file(req_file)
-        self.assertTrue('requests' in [req for req, version in requirements])
+        self.assertTrue('requests' in [req for req, version, ignore in requirements])
 
 
 if __name__ == '__main__':

--- a/piprot/test/test_parser.py
+++ b/piprot/test/test_parser.py
@@ -15,12 +15,20 @@ class TestRequirementsParser(unittest.TestCase):
         d = parse_req_file(f)
         self.assertTrue(d[0][0] == 'requests')
         self.assertTrue(d[0][1] == '1.2.3')
+        self.assertTrue(d[0][2] == False)
 
     def test_requirements_with_extra(self):
         f = StringIO("requests[security]==1.2.3")
         d = parse_req_file(f)
         self.assertEqual(d[0][0], 'requests')
         self.assertEqual(d[0][1], '1.2.3')
+
+    def test_requirements_ignore(self):
+        f = StringIO("requests==1.2.3  # norot")
+        d = parse_req_file(f)
+        self.assertEqual(d[0][0], 'requests')
+        self.assertEqual(d[0][1], '1.2.3')
+        self.assertEqual(d[0][2], True)
 
     def test_requirements_file(self):
         with open(


### PR DESCRIPTION
Adds support for a  # norot comment inside requirements files. When packages in requirements files end in a  # norot, they are ignored. 

I use piprot before I commit. For example
```
    piprot && make lint && make test
```

There are some packages I don't want to update, but I want piprot to still run sucessfully.