### PR TITLE
Use clean exit code when --delay is used and no deps are too outdated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ This is useful when you set up piprot in CI but cannot always upgrade the depend
 
     > piprot --delay 7
     ipython (1.1.0) is 5 days out of date. Latest is 1.1.1
-    All of your dependancies are at most 7 days out of date.
+    All of your dependencies are at most 7 days out of date.
     # Displays a warning but does not throw an error
 
 

--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -343,14 +343,13 @@ def main(
               "days out of date".format(verbatim_str, total_time_delta))
         sys.exit(1)
     elif delay is not None and max_outdated_time > int(delay):
-        print("{}At least one of your dependancies is {} "
+        print("{}At least one of your dependencies is {} "
               "days out of date which is more than the allowed"
               "{} days.".format(verbatim_str, max_outdated_time, delay))
         sys.exit(1)
     elif delay is not None and max_outdated_time <= int(delay):
-        print("{}All of your dependancies are at most {} "
+        print("{}All of your dependencies are at most {} "
               "days out of date.".format(verbatim_str, delay))
-        sys.exit(1)
     else:
         print("{}Looks like you've been keeping up to date, "
               "time for a delicious beverage!".format(verbatim_str))


### PR DESCRIPTION
The README file states that no error is thrown if all dependencies are less out
of date than the number of days specified in `--delay`, but an exit code of 1
was still used.

An exit code of 1 is the same as throwing an error so it should instead cause
piprot to use an exit code of 0.

I have at the same time fixed some typos in the word "dependencies" around that
part of the code and reflected it in the example output in the README file too.