### PR TITLE
Fix KeyError for packages with versions

### DIFF
--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -180,9 +180,13 @@ def get_version_and_release_date(
 
     try:
         if version:
-            if version in response["releases"]:
+            if version in response.get("releases", []):
                 release_date = response["releases"][version][0]["upload_time"]
-            else:
+            elif response.get("urls"):
+                for download in response['urls']:
+                    if download["packagetype"] == "sdist":
+                        release_date = download['upload_time']
+            if not release_date:
                 return None, None
         else:
             version = response["info"].get("stable_version")

--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -213,7 +213,7 @@ def get_version_and_release_date(
         return version, datetime.fromtimestamp(
             time.mktime(time.strptime(release_date, "%Y-%m-%dT%H:%M:%S"))
         )
-    except IndexError:
+    except (IndexError, KeyError):
         if verbose:
             print("{} ({}) didn't return a date property".format(requirement, version))
         return None, None


### PR DESCRIPTION
It seems the releases field no longer exists in the response of pypi if a version is specified, so I was seeing KeyErrror exceptions for them. This resolves this, while still supporting the old format (which can still be useful for older self hosted solutions).